### PR TITLE
X handle has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ Inside the project where you want to test your clone of the package, you can now
 
 ## Authors
 
--   Leo Lamprecht ([@notquiteleo](https://twitter.com/notquiteleo))
+-   Leo Lamprecht ([@leo](https://x.com/leo))
 -   Tim Neutkens ([@timneutkens](https://twitter.com/timneutkens)) - [Vercel](https://vercel.com)

--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Inside the project where you want to test your clone of the package, you can now
 ## Authors
 
 -   Leo Lamprecht ([@leo](https://x.com/leo))
--   Tim Neutkens ([@timneutkens](https://twitter.com/timneutkens)) - [Vercel](https://vercel.com)
+-   Tim Neutkens ([@timneutkens](https://x.com/timneutkens)) - [Vercel](https://vercel.com)


### PR DESCRIPTION
Twitter was renamed to X and my X handle changed from `@notquiteleo` to `@leo`.

This change replaces the previous broken link with the new working link.